### PR TITLE
scrub event.properties based on a whitelist

### DIFF
--- a/constants/propertiesWhitelist.js
+++ b/constants/propertiesWhitelist.js
@@ -1,0 +1,19 @@
+// In each tracking event, these are the properties which we retain and
+// pass through to mixpanel. We filter out all other properties.
+
+module.exports = [
+  "distinct_id",
+  "time",
+  "token",
+  "$app_version",
+  "HTTPS Everywhere",
+  "Tracking Protection Mode",
+  "Ad Block",
+  "Regional Ad Block",
+  "Fingerprinting Protection",
+  "JavaScript",
+  "Block Ads and Tracking",
+  "Block 3rd Party Cookies",
+  "Block Scripts",
+  "Top Shield"
+]

--- a/lib/mixpanelUtil.js
+++ b/lib/mixpanelUtil.js
@@ -5,6 +5,7 @@ const cookieUtil = require("./cookieUtil")
 const {decodeBase64, encodeBase64} = require("./base64Util")
 
 const MIXPANEL_TOKEN_WHITELIST = config.mixpanelTokenWhitelist.split(",")
+const PROPERTIES_WHITELIST = require("../constants/propertiesWhitelist")
 
 const isValidMixpanelToken = function (token) {
   if (!token) {
@@ -12,7 +13,7 @@ const isValidMixpanelToken = function (token) {
   }
   // HACK: Handle mixpanel iOS Swift 2.x library which sends token as "Optional({token})"
   return MIXPANEL_TOKEN_WHITELIST.some((whitelistToken) => {
-    return token.includes(whitelistToken)
+    return token === whitelistToken
   })
 }
 
@@ -43,8 +44,9 @@ const buildMixpanelTrackQueryString = function (request, response) {
     throw "Query missing"
   }
 
-  const data = decodeBase64(request.query.data)
+  let data = decodeBase64(request.query.data)
   assertValidMixpanelTrackEvent(data)
+  data = scrubEvent(data)
 
   let queryString = { data }
   // /track supports other params but not sure if we want them
@@ -95,6 +97,7 @@ const buildMixpanelTrackBody = function (request, response) {
   for (let i = 0; i < data.length; i++) {
     const event = data[i]
     assertValidMixpanelTrackEvent(event)
+    data[i] = scrubEvent(data[i])
 
     for (let key in restoredParams) {
       if (event.properties[key]) {
@@ -116,9 +119,33 @@ const buildMixpanelTrackBody = function (request, response) {
   return returnBody
 }
 
+/**
+ * Filter a mixpanel event's properties prop so it only has whitelisted
+ * ones.
+ * @param {object} event
+ * @returns {object} event with only whitelisted properties
+ */
+const scrubEvent = (event) => {
+  const newEvent = JSON.parse(JSON.stringify(event))
+  if (!event.properties || Object.keys(event.properties) === 0) {
+    return newEvent
+  }
+  newEvent.properties = {}
+  for (let prop of PROPERTIES_WHITELIST) {
+    if (!event.properties.hasOwnProperty(prop)) { continue }
+    if (typeof event.properties[prop] !== 'object') {
+      newEvent.properties[prop] = event.properties[prop]
+    } else {
+      newEvent.properties[prop] = JSON.parse(JSON.stringify(event.properties[prop]))
+    }
+  }
+  return newEvent
+}
+
 module.exports = {
   isValidMixpanelToken,
   assertValidMixpanelTrackEvent,
   buildMixpanelTrackQueryString,
-  buildMixpanelTrackBody
+  buildMixpanelTrackBody,
+  scrubEvent
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   },
   "scripts": {
     "start": "node index.js",
-    "test": "tape test/**/*Test.js"
+    "test": "NODE_ENV=test tape test/**/*Test.js"
   }
 }

--- a/test/app/trackRouterTest.js
+++ b/test/app/trackRouterTest.js
@@ -7,8 +7,9 @@ const request = require('request')
 const testHelper = require('../testHelper')
 const TrackRouter = require('../../app/trackRouter')
 const {decodeBase64, encodeBase64} = require("../../lib/base64Util")
-const USER_AGENT = require("../../lib/userAgent")
 const {setupServer} = require("../../lib/expressUtil")
+const PROPERTIES_WHITELIST = require("../../constants/propertiesWhitelist")
+const USER_AGENT = require("../../lib/userAgent")
 
 test('trackRouter', (t) => {
   t.plan(1)
@@ -49,7 +50,7 @@ test('trackRouter', (t) => {
     }
 
     t.test('Shared: GET /, POST /', (t) => {
-      t.plan(2)
+      t.plan(3)
 
       t.test('without params', (t) => {
         t.plan(2)
@@ -69,21 +70,91 @@ test('trackRouter', (t) => {
 
         const payload = {
           event: "sweet",
-          properties: {category: "sweet", token: config.mixpanelTokenWhitelist}
+          properties: {distinct_id: "42", token: config.mixpanelTokenWhitelist}
         }
         const checkPayload = (requestPayload) => {
           t.deepEquals(payload, decodeBase64(requestPayload.data), 'params pass through to mixpanel')
           return true
         }
+
+        const testPost = () => {
+          nock(config.mixpanelApiHost)
+            .post('/track', checkPayload)
+            .reply(200)
+          requestPost(payload)
+        }
         nock(config.mixpanelApiHost)
           .get('/track')
           .query(checkPayload)
           .reply(200)
-        requestGet(payload)
-        nock(config.mixpanelApiHost)
-          .post('/track', checkPayload)
-          .reply(200)
-        requestPost(payload)
+        requestGet(payload, {}, testPost)
+      })
+
+      t.test('properties filtering', (t) => {
+        t.plan(2)
+
+        // Prepare event which contains a mix of whitelisted and
+        // non-whitelisted propoerties.
+        const payload = {
+          event: "sweet",
+          properties: {}
+        }
+        const PROPERTIES_NOT_WHITELISTED = [
+          "mp_lib",
+          "$lib_version",
+          "$model"
+        ]
+        for (let prop of PROPERTIES_WHITELIST) {
+          payload.properties[prop] = 1
+        }
+        for (let prop of PROPERTIES_NOT_WHITELISTED) {
+          payload.properties[prop] = 1
+        }
+        payload.properties.token = config.mixpanelTokenWhitelist
+        const PROPERTIES_COUNT = PROPERTIES_WHITELIST.length + PROPERTIES_NOT_WHITELISTED.length
+
+        const checkPayloadEvent = function (event, t) {
+          for (let prop of PROPERTIES_WHITELIST) {
+            t.true(event.properties.hasOwnProperty(prop), `retains event properties."${prop}"`)
+          }
+          for (let prop of PROPERTIES_NOT_WHITELISTED) {
+            t.false(event.properties.hasOwnProperty(prop), `scrubs event properties."${prop}"`)
+          }
+        }
+
+        t.test('GET /', (t) => {
+          t.plan(PROPERTIES_COUNT)
+
+          const checkPayload = (requestPayload) => {
+            const decodedPayload = decodeBase64(requestPayload.data)
+            checkPayloadEvent(decodedPayload, t)
+            return true
+          }
+          nock(config.mixpanelApiHost)
+            .get('/track')
+            .query(checkPayload)
+            .reply(200)
+          requestGet(payload)
+        })
+
+        t.test('POST /', (t) => {
+          t.plan(PROPERTIES_COUNT * 2)
+
+          const postPayload = [
+            Object.assign({}, payload),
+            Object.assign({}, payload),
+          ]
+          const checkPayload = (requestPayload) => {
+            const decodedPayload = decodeBase64(requestPayload.data)
+            checkPayloadEvent(decodedPayload[0], t)
+            checkPayloadEvent(decodedPayload[1], t)
+            return true
+          }
+          nock(config.mixpanelApiHost)
+            .post('/track', checkPayload)
+            .reply(200)
+          requestPost(postPayload)
+        })
       })
     })
   })


### PR DESCRIPTION
Fix #3 

Note we also retain the [cookie persisted params](https://github.com/brave/metric-proxy/blob/master/lib/cookieUtil.js#L4), which support use with ad campaigns (landing page load event -> app install event).